### PR TITLE
Change lowercase postmap to camelcase postMap to match usage

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -54,7 +54,7 @@ module.exports = (eleventyConfig, configOptions = {}) => {
 
         options.prefix = (overrideOptions && overrideOptions.prefix) ? `${overrideOptions.prefix}-epg` : options.prefix
 
-        let postmap = {}
+        let postMap = {}
 
         if (options.data)
         {


### PR DESCRIPTION
The variable `postmap` is initialized as all lowercase but modified and used as camelCase (`postMap`).