### PR TITLE
Allow for no post.data

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -65,7 +65,7 @@ module.exports = (eleventyConfig, configOptions = {}) => {
                 counts: {},
             }
             for (let post of postsCollection) {
-                const postDate = post.data.date || post.date
+                const postDate = post.date || post.data.date
                 const postYear = moment(postDate).year()
                 const dateIndexKey = `${postYear}-${moment(postDate).dayOfYear()}`
                 if (!postMap.years[postYear]) {


### PR DESCRIPTION
In order to add support for the data structure that comes back from `https://github.com/declanbyrd/eleventy-plugin-mastoarchive`, I flipped the conditional for post.date or post.data.date check