### PR TITLE
Add date title element to highlighted boxes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,6 +9,8 @@ const makeOptions = (options) => {
         prefix: options.prefix ? `${options.prefix}-epg` : 'epg',
         noLabels: options.noLabels || false,
         yearLink: options.yearLink || null,
+        dayBoxTitle: options.dayBoxTitle || false,
+        dayBoxTitleFormat: options.dayBoxTitleFormat || 'MMM D, YYYY',
         
         selectorLight: options.selectorLight || ':root',
         selectorDark: options.selectorDark || null,
@@ -178,7 +180,7 @@ module.exports = (eleventyConfig, configOptions = {}) => {
                     Array.from({ length: postMap.years[year].days }).map((_, index) => {
                         const dateIndexKey = `${year}-${index + 1}`
                         const postCount = postMap.counts[dateIndexKey] || 0
-                        return `<div class="${prefix}__box ${ postCount > 0 ? `${prefix}__hasPost` : '' }" title="${ postCount > 0 ? `${moment().year(year).dayOfYear(index + 1).format('MMM D, YYYY')}` : ''}"></div>`
+                        return `<div class="${prefix}__box ${ postCount > 0 ? `${prefix}__hasPost` : '' }" title="${ options.dayBoxTitle && postCount > 0 ? `${moment().year(year).dayOfYear(index + 1).format(options.dayBoxTitleFormat)}` : ''}"></div>`
                     }).join('')
                 }
                 </div></div>`

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -180,7 +180,7 @@ module.exports = (eleventyConfig, configOptions = {}) => {
                     Array.from({ length: postMap.years[year].days }).map((_, index) => {
                         const dateIndexKey = `${year}-${index + 1}`
                         const postCount = postMap.counts[dateIndexKey] || 0
-                        return `<div class="${prefix}__box ${ postCount > 0 ? `${prefix}__hasPost` : '' }" title="${ options.dayBoxTitle && postCount > 0 ? `${moment().year(year).dayOfYear(index + 1).format(options.dayBoxTitleFormat)}` : ''}"></div>`
+                        return `<div class="${prefix}__box ${ postCount > 0 ? `${prefix}__hasPost` : '' }" ${ options.dayBoxTitle && postCount > 0 ? `title="${moment().year(year).dayOfYear(index + 1).format(options.dayBoxTitleFormat)}"` : ''}></div>`
                     }).join('')
                 }
                 </div></div>`

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -178,7 +178,7 @@ module.exports = (eleventyConfig, configOptions = {}) => {
                     Array.from({ length: postMap.years[year].days }).map((_, index) => {
                         const dateIndexKey = `${year}-${index + 1}`
                         const postCount = postMap.counts[dateIndexKey] || 0
-                        return `<div class="${prefix}__box ${ postCount > 0 ? `${prefix}__hasPost` : '' }"></div>`
+                        return `<div class="${prefix}__box ${ postCount > 0 ? `${prefix}__hasPost` : '' }" title="${ postCount > 0 ? `${moment().year(year).dayOfYear(index + 1).format('MMM D, YYYY')}` : ''}"></div>`
                     }).join('')
                 }
                 </div></div>`

--- a/demo/index.njk
+++ b/demo/index.njk
@@ -136,6 +136,17 @@ eleventyConfig.addPlugin(postGraph, {
 })
 ```
 
+### Show dates on highlighted box hover
+
+Adds a `title` element to each highlighted box with the date of the post. The default display is `Aug 6, 2024`, but this can be updated using <a href="https://momentjs.com/docs/#/displaying/" target="_blank">Moment's formatting options</a>:
+
+```js
+eleventyConfig.addPlugin(postGraph, {
+    dayBoxTitle: true,
+    dayBoxTitleFormat: 'MMM D, YYYY',
+})
+```
+
 ### Customise styles
 
 Pass in `noStyles: true` to do all the styling yourself. Note: If you have a CSP that blocks inline css, you will need to include the styles yourself.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c06288a6-4795-44f0-9470-643b5566ea46)

If a box on the graph is highlighted, allow users to hover and see the date via a `title` element.

- Added 2 new options, `dayBoxTitle` (default `false`) and `dayBoxTitleFormat` (default `MMM D, YYYY` for `Aug 6, 2024`)
- Updated the readme for the demo